### PR TITLE
jQuery UI Integration for Reorder Modules and Contents

### DIFF
--- a/courses/templates/courses/manage/content/form.html
+++ b/courses/templates/courses/manage/content/form.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}
+  {% if object %}
+    Edit content "{{ object.title }}"
+  {% else %}
+    Add new content
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+  <h1>
+    {% if object %}
+      Edit content "{{ object.title }}"
+    {% else %}
+      Add new content
+    {% endif %}
+  </h1>
+  <div class="module">
+    <h2>Course info</h2>
+    <form method="post" enctype="multipart/form-data">
+      {{ form.as_p }}
+      {% csrf_token %}
+      <p><input type="submit" value="Save content"></p>
+    </form>
+  </div>
+{% endblock %}

--- a/courses/templates/courses/manage/course/list.html
+++ b/courses/templates/courses/manage/course/list.html
@@ -13,6 +13,10 @@
           <a href="{% url "course_edit" course.id %}">Edit</a>
           <a href="{% url "course_delete" course.id %}">Delete</a>
           <a href="{% url "course_module_update" course.id %}">Edit modules</a>
+          {% if course.modules.count > 0 %}
+              <a href="{% url "module_content_list" course.modules.first.id %}">
+              Manage contents</a>
+          {% endif %}
         </p>
       </div>
     {% empty %}

--- a/courses/templates/courses/manage/module/content_list.html
+++ b/courses/templates/courses/manage/module/content_list.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% load course %}
+
+{% block title %}
+  Module {{ module.order|add:1 }}: {{ module.title }}
+{% endblock %}
+
+{% block content %}
+  {% with course=module.course %}
+    <h1>Course "{{ course.title }}"</h1>
+    <div class="contents">
+      <h3>Modules</h3>
+      <ul id="modules">
+        {% for m in course.modules.all %}
+          <li data-id="{{ m.id }}" {% if m == module %}
+           class="selected"{% endif %}>
+            <a href="{% url "module_content_list" m.id %}">
+              <span>
+                Module <span class="order">{{ m.order|add:1 }}</span>
+              </span>
+              <br>
+              {{ m.title }}
+            </a>
+          </li>
+        {% empty %}
+          <li>No modules yet.</li>
+        {% endfor %}
+      </ul>
+      <p><a href="{% url "course_module_update" course.id %}">
+      Edit modules</a></p>
+    </div>
+    <div class="module">
+      <h2>Module {{ module.order|add:1 }}: {{ module.title }}</h2>
+      <h3>Module contents:</h3>
+
+      <div id="module-contents">
+        {% for content in module.contents.all %}
+          <div data-id="{{ content.id }}">
+            {% with item=content.item %}
+              <p>{{ item }} ({{ item|model_name }})</p>
+              <a href="{% url "module_content_update" module.id item|model_name item.id %}">
+                Edit
+              </a>
+              <form action="{% url "module_content_delete" content.id %}" method="post">
+                <input type="submit" value="Delete">
+                {% csrf_token %}
+              </form>
+            {% endwith %}
+          </div>
+        {% empty %}
+          <p>This module has no contents yet.</p>
+        {% endfor %}
+      </div>
+      <h3>Add new content:</h3>
+      <ul class="content-types">
+        <li><a href="{% url "module_content_create" module.id "text" %}">
+        Text</a></li>
+        <li><a href="{% url "module_content_create" module.id "image" %}">
+        Image</a></li>
+        <li><a href="{% url "module_content_create" module.id "video" %}">
+        Video</a></li>
+        <li><a href="{% url "module_content_create" module.id "file" %}">
+        File</a></li>
+      </ul>
+    </div>
+  {% endwith %}
+{% endblock %}

--- a/courses/templates/courses/manage/module/content_list.html
+++ b/courses/templates/courses/manage/module/content_list.html
@@ -65,3 +65,42 @@
     </div>
   {% endwith %}
 {% endblock %}
+
+{% block domready %}
+  $('#modules').sortable({
+      stop: function(event, ui) {
+          modules_order = {};
+          $('#modules').children().each(function(){
+              // update the order field
+              $(this).find('.order').text($(this).index() + 1);
+              // associate the module's id with its order
+              modules_order[$(this).data('id')] = $(this).index();
+          });
+          $.ajax({
+              type: 'POST',
+              url: '{% url "module_order" %}',
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              data: JSON.stringify(modules_order)
+          });
+      }
+  });
+
+  $('#module-contents').sortable({
+      stop: function(event, ui) {
+          contents_order = {};
+          $('#module-contents').children().each(function(){
+              // associate the module's id with its order
+              contents_order[$(this).data('id')] = $(this).index();
+          });
+
+          $.ajax({
+              type: 'POST',
+              url: '{% url "content_order" %}',
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              data: JSON.stringify(contents_order),
+          });
+      }
+  });
+{% endblock %}

--- a/courses/templatetags/course.py
+++ b/courses/templatetags/course.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def model_name(obj):
+    try:
+        return obj._meta.model_name 
+    except AttributeError:
+        return None
+    

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -7,4 +7,20 @@ urlpatterns = [
     path('<pk>/edit/', views.CourseUpdateView.as_view(), name='course_edit'),
     path('<pk>/delete/', views.CourseDeleteView.as_view(), name='course_delete'),
     path('<pk>/module/', views.CourseModuleUpdateView.as_view(), name='course_module_update'),
+    
+    path('module/<int:module_id>/content/<model_name>/create/', 
+         views.ContentCreateUpdateView.as_view(), 
+         name='module_content_create'),
+         
+    path('module/<int:module_id>/content/<model_name>/<id>/', 
+         views.ContentCreateUpdateView.as_view(), 
+         name='module_content_update'),
+
+    path('content/<int:id>/delete/', 
+         views.ContentDeleteView.as_view(), 
+         name='module_content_delete'),
+
+    path('module/<int:module_id>/',
+         views.ModuleContentListView.as_view(),
+         name='module_content_list'),
 ]

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path('<pk>/edit/', views.CourseUpdateView.as_view(), name='course_edit'),
     path('<pk>/delete/', views.CourseDeleteView.as_view(), name='course_delete'),
     path('<pk>/module/', views.CourseModuleUpdateView.as_view(), name='course_module_update'),
-    
+
     path('module/<int:module_id>/content/<model_name>/create/', 
          views.ContentCreateUpdateView.as_view(), 
          name='module_content_create'),
@@ -23,4 +23,14 @@ urlpatterns = [
     path('module/<int:module_id>/',
          views.ModuleContentListView.as_view(),
          name='module_content_list'),
+    
+    path('module/order/',
+         views.ModuleOrderView.as_view(),
+         name='module_order'),
+    
+    path('content/order/',
+         views.ContentOrderView.as_view(),
+         name='content_order'),
+
+    
 ]

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,5 +1,5 @@
 from django.views.generic.list import ListView
-from .models import Course 
+from .models import Course, Module, Content
 from django.urls import reverse_lazy
 from django.views.generic.list import ListView
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
@@ -7,6 +7,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMix
 from django.shortcuts import redirect, get_object_or_404
 from django.views.generic.base import TemplateResponseMixin, View
 from .forms import ModuleFormSet
+from django.forms.models import modelform_factory
+from django.apps import apps
 
 # Create your views here.
 class OwnerMixin(object):
@@ -63,3 +65,56 @@ class CourseModuleUpdateView(TemplateResponseMixin, View):
         if formset.is_valid():
             return redirect('manage_course_list')
         return self.render_to_response({'course': self.course, 'formset': formset})
+    
+class ContentCreateUpdateView(TemplateResponseMixin, View):
+    module = None
+    model = None 
+    obj = None
+    template_name = 'courses/manage/content/form.html'
+
+    def get_model(self, model_name):
+        if model_name in ['text', 'video', 'image', 'file']:
+            return apps.get_model(app_label='courses', model_name=model_name)
+        return None
+
+    def get_form(self, model, *args, **kwargs):
+        Form = modelform_factory(model, exclude=['owner', 'order', 'created', 'updated'])
+        return Form(*args, **kwargs)
+
+    def dispatch(self, request, module_id, model_name, id=None):
+        self.module = get_object_or_404(Module, id=module_id, course__owner=request.user)
+        self.model = self.get_model(model_name)
+        if id:
+            self.obj = get_object_or_404(self.model, id=id, owner=request.user)
+        return super().dispatch(request, module_id, model_name, id)
+
+    def get(self, request, module_id, module_name, id=None):
+        form = self.get_form(self.model, instance=self.obj)
+        return self.render_to_response({'form': form, 'object': self.obj})
+
+    def post(self, request, module_id, model_name, id=None):
+        form = self.get_form(self.model, instance=self.obj, data=request.POST, files=request.FILES)
+
+        if form.is_valid():
+            obj = form.save(commit=False)
+            obj.owner = request.user
+            obj.save()
+            if not id:
+                Content.objects.create(module=self.module, item=obj)
+            return redirect('module_content_list', self.module.id)
+        return self.render_to_response({'form': form, 'object': self.obj})
+
+class ContentDeleteView(View):
+
+    def post(self, request, id):
+        content = get_object_or_404(Content, id=id, module__course__owner=request.user)
+        module = content.item.delete()
+        content.delete()
+        return redirect('module_content_list', module.id)
+
+class ModuleContentListView(TemplateResponseMixin, View):
+    template_name = 'courses/manage/module/content_list.html'
+
+    def get(self, request, module_id):
+        module = get_object_or_404(Module, id=module_id, course__owner=request.user)
+        return self.render_to_response({'module': module})

--- a/courses/views.py
+++ b/courses/views.py
@@ -9,6 +9,7 @@ from django.views.generic.base import TemplateResponseMixin, View
 from .forms import ModuleFormSet
 from django.forms.models import modelform_factory
 from django.apps import apps
+from braces.views import CsrfExemptMixin, JsonRequestResponseMixin
 
 # Create your views here.
 class OwnerMixin(object):
@@ -118,3 +119,15 @@ class ModuleContentListView(TemplateResponseMixin, View):
     def get(self, request, module_id):
         module = get_object_or_404(Module, id=module_id, course__owner=request.user)
         return self.render_to_response({'module': module})
+    
+class ModuleOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):
+    def post(self, request):
+        for id, order in self.request_json.items():
+            Module.objects.filters(id=id, course__owner=request.user).update(order=order)
+        return self.render_json_response({'saved':'OK'})
+
+class ContentOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):
+    def post(self, request):
+        for id, order in self.request_json.items():
+            Content.objects.filter(id=id, module__course__owner=request.user).update(order=order)
+        return self.render_json_response({'saved': 'OK'})


### PR DESCRIPTION
### Changes Made:

- Added views for reordering modules (`ModuleOrderView`) and contents (`ContentOrderView`) using AJAX requests.
- Integrated django-braces mixins (`CsrfExemptMixin`, `JsonRequestResponseMixin`) to handle CSRF exemption and JSON requests/responses.
- Added corresponding URL patterns for ordering modules and contents.
- Integrated jQuery UI for drag-and-drop functionality to reorder modules and contents in the `courses/manage/module/content_list.html` template.
