### PR TITLE
jQuery UI Integration for Reorder Modules and Contents

### DIFF
--- a/courses/templates/courses/manage/module/content_list.html
+++ b/courses/templates/courses/manage/module/content_list.html
@@ -65,3 +65,42 @@
     </div>
   {% endwith %}
 {% endblock %}
+
+{% block domready %}
+  $('#modules').sortable({
+      stop: function(event, ui) {
+          modules_order = {};
+          $('#modules').children().each(function(){
+              // update the order field
+              $(this).find('.order').text($(this).index() + 1);
+              // associate the module's id with its order
+              modules_order[$(this).data('id')] = $(this).index();
+          });
+          $.ajax({
+              type: 'POST',
+              url: '{% url "module_order" %}',
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              data: JSON.stringify(modules_order)
+          });
+      }
+  });
+
+  $('#module-contents').sortable({
+      stop: function(event, ui) {
+          contents_order = {};
+          $('#module-contents').children().each(function(){
+              // associate the module's id with its order
+              contents_order[$(this).data('id')] = $(this).index();
+          });
+
+          $.ajax({
+              type: 'POST',
+              url: '{% url "content_order" %}',
+              contentType: 'application/json; charset=utf-8',
+              dataType: 'json',
+              data: JSON.stringify(contents_order),
+          });
+      }
+  });
+{% endblock %}

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path('<pk>/edit/', views.CourseUpdateView.as_view(), name='course_edit'),
     path('<pk>/delete/', views.CourseDeleteView.as_view(), name='course_delete'),
     path('<pk>/module/', views.CourseModuleUpdateView.as_view(), name='course_module_update'),
-    
+
     path('module/<int:module_id>/content/<model_name>/create/', 
          views.ContentCreateUpdateView.as_view(), 
          name='module_content_create'),
@@ -23,4 +23,14 @@ urlpatterns = [
     path('module/<int:module_id>/',
          views.ModuleContentListView.as_view(),
          name='module_content_list'),
+    
+    path('module/order/',
+         views.ModuleOrderView.as_view(),
+         name='module_order'),
+    
+    path('content/order/',
+         views.ContentOrderView.as_view(),
+         name='content_order'),
+
+    
 ]

--- a/courses/views.py
+++ b/courses/views.py
@@ -9,6 +9,7 @@ from django.views.generic.base import TemplateResponseMixin, View
 from .forms import ModuleFormSet
 from django.forms.models import modelform_factory
 from django.apps import apps
+from braces.views import CsrfExemptMixin, JsonRequestResponseMixin
 
 # Create your views here.
 class OwnerMixin(object):
@@ -118,3 +119,15 @@ class ModuleContentListView(TemplateResponseMixin, View):
     def get(self, request, module_id):
         module = get_object_or_404(Module, id=module_id, course__owner=request.user)
         return self.render_to_response({'module': module})
+    
+class ModuleOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):
+    def post(self, request):
+        for id, order in self.request_json.items():
+            Module.objects.filters(id=id, course__owner=request.user).update(order=order)
+        return self.render_json_response({'saved':'OK'})
+
+class ContentOrderView(CsrfExemptMixin, JsonRequestResponseMixin, View):
+    def post(self, request):
+        for id, order in self.request_json.items():
+            Content.objects.filter(id=id, module__course__owner=request.user).update(order=order)
+        return self.render_json_response({'saved': 'OK'})


### PR DESCRIPTION
## Description
This pull request introduces the ability to order modules by clicking and dragging them, utilizing jQuery UI integration and AJAX.
### Changes Made:

- Added views for reordering modules (`ModuleOrderView`) and contents (`ContentOrderView`) using AJAX requests.
- Integrated django-braces mixins (`CsrfExemptMixin`, `JsonRequestResponseMixin`) to handle CSRF exemption and JSON requests/responses.
- Added corresponding URL patterns for ordering modules and contents.
- Integrated jQuery UI for drag-and-drop functionality to reorder modules and contents in the `courses/manage/module/content_list.html` template.
- Included necessary JavaScript code in the template to handle the sorting functionality and perform AJAX requests to update the order.
